### PR TITLE
feat: dzs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
           "zenscript"
         ],
         "extensions": [
-          ".zs"
+          ".zs",
+          ".dzs"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test:update": "vitest --typecheck -u"
   },
   "dependencies": {
+    "@stoplight/json-ref-resolver": "^3.1.6",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/zenscript/langium-config.json
+++ b/packages/zenscript/langium-config.json
@@ -4,7 +4,7 @@
     {
       "id": "zenscript",
       "grammar": "src/zenscript.langium",
-      "fileExtensions": [".zs"],
+      "fileExtensions": [".zs", ".dzs"],
       "textMate": {
         "out": "../../syntaxes/zenscript.tmLanguage.json"
       }

--- a/packages/zenscript/src/name.ts
+++ b/packages/zenscript/src/name.ts
@@ -56,4 +56,3 @@ function concat(qualifiedName: string, name: string): string {
   }
   return [...qualifiedName.split('.'), name].join('.')
 }
-

--- a/packages/zenscript/src/name.ts
+++ b/packages/zenscript/src/name.ts
@@ -31,20 +31,20 @@ export class ZenScriptNameProvider implements NameProvider {
   getQualifiedName(node: AstNode): string | undefined {
     const document = AstUtils.getDocument<Script>(node)
     if (!document) {
-      return undefined
+      return
     }
 
-    const dqName = getQualifiedName(document)
-    if (!dqName) {
-      return undefined
+    const name = getQualifiedName(document)
+    if (name === undefined) {
+      return
     }
 
     if (isScript(node)) {
-      return dqName
+      return name
     }
     else if (isToplevel(node)) {
       if (isVariableDeclaration(node) || isFunctionDeclaration(node) || isClassDeclaration(node)) {
-        return concat(dqName, node.name)
+        return concat(name, node.name)
       }
     }
   }

--- a/packages/zenscript/src/name.ts
+++ b/packages/zenscript/src/name.ts
@@ -1,8 +1,9 @@
-import type { AstNode, CstNode, LangiumDocument, NameProvider } from 'langium'
-import { AstUtils, GrammarUtils, UriUtils, isNamed } from 'langium'
-import { substringBeforeLast } from '@intellizen/shared'
+import type { AstNode, CstNode, NameProvider } from 'langium'
+import { AstUtils, GrammarUtils, isNamed } from 'langium'
+import type { Script } from './generated/ast'
 import { isClassDeclaration, isFunctionDeclaration, isImportDeclaration, isScript, isVariableDeclaration } from './generated/ast'
 import { isToplevel } from './utils/ast'
+import { getName, getQualifiedName } from './utils/document'
 
 declare module 'langium' {
   interface NameProvider {
@@ -28,7 +29,7 @@ export class ZenScriptNameProvider implements NameProvider {
   }
 
   getQualifiedName(node: AstNode): string | undefined {
-    const document = AstUtils.getDocument(node)
+    const document = AstUtils.getDocument<Script>(node)
     if (!document) {
       return undefined
     }
@@ -53,22 +54,6 @@ function concat(qualifiedName: string, name: string): string {
   if (!qualifiedName) {
     return name
   }
-  const names = [...qualifiedName.split('.'), name]
-  return names.join('.')
+  return [...qualifiedName.split('.'), name].join('.')
 }
 
-function getQualifiedName(document: LangiumDocument): string | undefined {
-  if (!document.srcRootUri) {
-    return undefined
-  }
-
-  const docName = getName(document)
-  const relatives = UriUtils.relative(document.srcRootUri, document.uri).split('/')
-  const names = ['scripts', ...relatives.slice(0, -1), docName]
-  return names.join('.')
-}
-
-function getName(document: LangiumDocument): string {
-  const baseName = UriUtils.basename(document.uri)
-  return substringBeforeLast(baseName, '.')
-}

--- a/packages/zenscript/src/scoping/scope-computation.ts
+++ b/packages/zenscript/src/scoping/scope-computation.ts
@@ -1,18 +1,19 @@
 import type { AstNode, AstNodeDescription, LangiumDocument, PrecomputedScopes } from 'langium'
-import { AstUtils, DefaultScopeComputation } from 'langium'
-import type { ClassDeclaration, ValueParameter } from '../generated/ast'
+import { DefaultScopeComputation } from 'langium'
+import type { ClassDeclaration, Script, ValueParameter } from '../generated/ast'
 import { isClassDeclaration, isFunctionDeclaration, isScript, isValueParameter, isVariableDeclaration } from '../generated/ast'
 import type { ZenScriptServices } from '../module'
 import { isToplevel } from '../utils/ast'
+import { getQualifiedName, isZs } from '../utils/document'
 
 export class ZenScriptScopeComputation extends DefaultScopeComputation {
   constructor(services: ZenScriptServices) {
     super(services)
   }
 
-  protected override exportNode(node: AstNode, exports: AstNodeDescription[], document: LangiumDocument): void {
+  protected override exportNode(node: AstNode, exports: AstNodeDescription[], document: LangiumDocument<Script>): void {
     // TODO: workaround, needs rewrite
-    if (isScript(node)) {
+    if (isScript(node) && isZs(document)) {
       const name = this.nameProvider.getQualifiedName(node)
       exports.push(this.descriptions.createDescription(node, name, document))
     }
@@ -23,7 +24,7 @@ export class ZenScriptScopeComputation extends DefaultScopeComputation {
     }
 
     // script from an unknown package export nothing
-    if (!this.nameProvider.getQualifiedName(AstUtils.findRootNode(node))) {
+    if (getQualifiedName(document) === undefined) {
       return
     }
 

--- a/packages/zenscript/src/scoping/scope-provider.ts
+++ b/packages/zenscript/src/scoping/scope-provider.ts
@@ -16,7 +16,7 @@ const builtin: AstNodeDescription[] = ['any', 'byte', 'short', 'int', 'long', 'f
   .map(name => ({
     type: ClassDeclaration,
     name,
-    documentUri: URI.parse(`builtin:///${name}`),
+    documentUri: URI.from({ scheme: 'intellizen', path: `/builtin/${name}` }),
     path: '',
   }))
 

--- a/packages/zenscript/src/scoping/scope-provider.ts
+++ b/packages/zenscript/src/scoping/scope-provider.ts
@@ -110,10 +110,12 @@ export class ZenScriptScopeProvider extends DefaultScopeProvider {
         if (!script) {
           return EMPTY_SCOPE
         }
+
         const globals = stream(this.packageManager.getHierarchyNode('')!.children.values())
           .map(it => it.value)
           .filter(it => isClassDeclaration(it))
           .map(it => this.descriptions.createDescription(it, it.name))
+
         const imports = script.imports
           .map((it) => {
             const desc = it.path.at(-1)?.$nodeDescription ?? this.descriptions.createDescription(it, undefined)
@@ -121,11 +123,14 @@ export class ZenScriptScopeProvider extends DefaultScopeProvider {
             return desc
           })
           .filter(it => !!it)
-        const scriptStatic = script.classes.map(it => this.descriptions.createDescription(it, it.name))
+
+        const locals = script.classes
+          .map(it => this.descriptions.createDescription(it, it.name))
+
         let scope = this.createScope(builtin)
         scope = this.createScope(globals, scope)
         scope = this.createScope(imports, scope)
-        scope = this.createScope(scriptStatic, scope)
+        scope = this.createScope(locals, scope)
         return scope
       }
       else if (source.index !== undefined) {

--- a/packages/zenscript/src/scoping/scope-provider.ts
+++ b/packages/zenscript/src/scoping/scope-provider.ts
@@ -110,18 +110,14 @@ export class ZenScriptScopeProvider extends DefaultScopeProvider {
         if (!script) {
           return EMPTY_SCOPE
         }
-        const globals: AstNodeDescription[] = []
-        for (const global of this.packageManager.getHierarchyNode('')!.children.values()) {
-          if (isClassDeclaration(global.value)) {
-            globals.push(this.descriptions.createDescription(global.value, global.value.name))
-          }
-        }
+        const globals = stream(this.packageManager.getHierarchyNode('')!.children.values())
+          .map(it => it.value)
+          .filter(it => isClassDeclaration(it))
+          .map(it => this.descriptions.createDescription(it, it.name))
         const imports = script.imports
           .map((it) => {
-            const desc = it.path[it.path.length - 1]?.$nodeDescription
-            if (desc && it.alias) {
-              desc.name = it.alias
-            }
+            const desc = it.path.at(-1)?.$nodeDescription ?? this.descriptions.createDescription(it, undefined)
+            desc.name = this.nameProvider.getName(it) ?? desc.name
             return desc
           })
           .filter(it => !!it)

--- a/packages/zenscript/src/typing/description.ts
+++ b/packages/zenscript/src/typing/description.ts
@@ -1,19 +1,8 @@
 import type { Reference } from 'langium'
-import type { ClassDeclaration, PrimitiveTypeReference } from '../generated/ast'
+import type { ClassDeclaration } from '../generated/ast'
 
 // region TypeDescription
 export interface TypeDescConstants {
-  any: PrimitiveTypeDescription
-  void: PrimitiveTypeDescription
-  string: PrimitiveTypeDescription
-  bool: PrimitiveTypeDescription
-  byte: PrimitiveTypeDescription
-  short: PrimitiveTypeDescription
-  int: PrimitiveTypeDescription
-  long: PrimitiveTypeDescription
-  float: PrimitiveTypeDescription
-  double: PrimitiveTypeDescription
-
   function: FunctionTypeDescription
   class: ClassTypeDescription
   proper: ProperTypeDescription
@@ -32,23 +21,6 @@ export class TypeDescription<T extends keyof TypeDescConstants = keyof TypeDescC
   constructor($type: T) {
     this.$type = $type
   }
-}
-
-export class PrimitiveTypeDescription extends TypeDescription<PrimitiveTypeReference['value']> {
-  constructor($type: PrimitiveTypeReference['value']) {
-    super($type)
-  }
-
-  static ANY = new PrimitiveTypeDescription('any')
-  static BOOL = new PrimitiveTypeDescription('bool')
-  static BYTE = new PrimitiveTypeDescription('byte')
-  static SHORT = new PrimitiveTypeDescription('short')
-  static INT = new PrimitiveTypeDescription('int')
-  static LONG = new PrimitiveTypeDescription('long')
-  static FLOAT = new PrimitiveTypeDescription('float')
-  static DOUBLE = new PrimitiveTypeDescription('double')
-  static STRING = new PrimitiveTypeDescription('string')
-  static VOID = new PrimitiveTypeDescription('void')
 }
 
 export class FunctionTypeDescription extends TypeDescription<'function'> {
@@ -70,6 +42,17 @@ export class ClassTypeDescription extends TypeDescription<'class'> {
     super('class')
     this.className = className
   }
+
+  static ANY = new ClassTypeDescription('any')
+  static BOOL = new ClassTypeDescription('bool')
+  static BYTE = new ClassTypeDescription('byte')
+  static SHORT = new ClassTypeDescription('short')
+  static INT = new ClassTypeDescription('int')
+  static LONG = new ClassTypeDescription('long')
+  static FLOAT = new ClassTypeDescription('float')
+  static DOUBLE = new ClassTypeDescription('double')
+  static STRING = new ClassTypeDescription('string')
+  static VOID = new ClassTypeDescription('void')
 }
 
 export class ProperTypeDescription extends TypeDescription<'proper'> {
@@ -142,48 +125,44 @@ export class PackageTypeDescription extends TypeDescription<'package'> {
 // endregion
 
 // region Predicates
-export function isStringTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'string'
+export function isStringType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'string'
 }
 
-export function isAnyTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'any'
+export function isAnyType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'any'
 }
 
-export function isBoolTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'bool'
+export function isBoolType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'bool'
 }
 
-export function isByteTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'byte'
+export function isByteType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'byte'
 }
 
-export function isDoubleTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'double'
+export function isDoubleType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'double'
 }
 
-export function isFloatTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'float'
+export function isFloatType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'float'
 }
 
-export function isIntTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'int'
+export function isIntType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'int'
 }
 
-export function isLongTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'long'
+export function isLongType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'long'
 }
 
-export function isShortTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'short'
+export function isShortType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'short'
 }
 
-export function isVoidTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc?.$type === 'void'
-}
-
-export function isPrimitiveTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is PrimitiveTypeDescription {
-  return typeDesc instanceof PrimitiveTypeDescription
+export function isVoidType(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {
+  return isClassTypeDescription(typeDesc) && typeDesc.className === 'void'
 }
 
 export function isClassTypeDescription(typeDesc: TypeDescription | undefined): typeDesc is ClassTypeDescription {

--- a/packages/zenscript/src/utils/ast.ts
+++ b/packages/zenscript/src/utils/ast.ts
@@ -29,7 +29,7 @@ export function getClassMembers(clazz?: ClassDeclaration) {
 }
 
 export function isStaticMember(member: ClassMemberDeclaration) {
-  return member.$type !== 'ConstructorDeclaration' && member.prefix === 'static'
+  return 'prefix' in member && member.prefix === 'static'
 }
 
 export function toQualifiedName(importDecl: ImportDeclaration, context: ReferenceInfo): string {

--- a/packages/zenscript/src/utils/document.ts
+++ b/packages/zenscript/src/utils/document.ts
@@ -1,0 +1,40 @@
+import { substringBeforeLast } from '@intellizen/shared'
+import type { LangiumDocument } from 'langium'
+import { UriUtils } from 'langium'
+import type { Script } from '../generated/ast'
+
+export function isZs(document: LangiumDocument): boolean {
+  return UriUtils.extname(document.uri) === '.zs'
+}
+
+export function isDzs(document: LangiumDocument): boolean {
+  return UriUtils.extname(document.uri) === '.dzs'
+}
+
+export function getName(document: LangiumDocument): string {
+  const baseName = UriUtils.basename(document.uri)
+  return substringBeforeLast(baseName, '.')
+}
+
+export function getQualifiedName(document: LangiumDocument<Script>): string | undefined {
+  if (isZs(document)) {
+    const srcRootUri = document.srcRootUri
+    if (srcRootUri) {
+      const relatives = UriUtils.relative(srcRootUri, document.uri).split('/')
+      const docName = getName(document)
+      return ['scripts', ...relatives.slice(0, -1), docName].join('.')
+    }
+  }
+  else if (isDzs(document)) {
+    const packageDecl = document.parseResult.value.package
+    if (packageDecl) {
+      return packageDecl.path.join('.')
+    }
+
+    const srcRootUri = document.srcRootUri
+    if (srcRootUri) {
+      const relatives = UriUtils.relative(document.srcRootUri, document.uri).split('/')
+      return relatives.slice(0, -1).join('.')
+    }
+  }
+}

--- a/packages/zenscript/src/utils/document.ts
+++ b/packages/zenscript/src/utils/document.ts
@@ -26,15 +26,6 @@ export function getQualifiedName(document: LangiumDocument<Script>): string | un
     }
   }
   else if (isDzs(document)) {
-    const packageDecl = document.parseResult.value.package
-    if (packageDecl) {
-      return packageDecl.path.join('.')
-    }
-
-    const srcRootUri = document.srcRootUri
-    if (srcRootUri) {
-      const relatives = UriUtils.relative(document.srcRootUri, document.uri).split('/')
-      return relatives.slice(0, -1).join('.')
-    }
+    return document.parseResult.value.package?.path.join('.') ?? ''
   }
 }

--- a/packages/zenscript/src/utils/error.ts
+++ b/packages/zenscript/src/utils/error.ts
@@ -3,7 +3,7 @@ import { StringConstants } from '../workspace/configurations'
 
 export class ConfigError extends Error {
   constructor(workspaceFolder: WorkspaceFolder, options?: ErrorOptions) {
-    super(`An error occurred parsing "${StringConstants.Config.intellizen}" located in the workspace folder "${workspaceFolder.name}".`, options)
+    super(`An error occurred parsing "${StringConstants.File.intellizen}" located in the workspace folder "${workspaceFolder.name}".`, options)
   }
 }
 

--- a/packages/zenscript/src/workspace/configuration-manager.ts
+++ b/packages/zenscript/src/workspace/configuration-manager.ts
@@ -1,6 +1,7 @@
 import { resolve as resolvePath } from 'node:path'
 import type { FileSystemProvider, WorkspaceFolder } from 'langium'
 import { URI, UriUtils } from 'langium'
+import { Resolver } from '@stoplight/json-ref-resolver'
 import { existsDirectory, existsFile, findInside, isDirectory, isFile } from '../utils/fs'
 import type { ZenScriptSharedServices } from '../module'
 import { ConfigError, DirectoryNotFoundError, EntryError, FileNotFoundError } from '../utils/error'
@@ -49,7 +50,9 @@ export class ZenScriptConfigurationManager implements ConfigurationManager {
 
   private async load(parsedConfig: ParsedConfig, configUri: URI) {
     const content = await this.fileSystemProvider.readFile(configUri)
-    const config = IntelliZenSchema.parse(JSON.parse(content))
+    const json = JSON.parse(content)
+    const resolved = await new Resolver().resolve(json)
+    const config = IntelliZenSchema.parse(resolved.result)
 
     for (const srcRoot of config.srcRoots) {
       const srcRootPath = resolvePath(configUri.fsPath, '..', srcRoot)
@@ -61,13 +64,13 @@ export class ZenScriptConfigurationManager implements ConfigurationManager {
       }
     }
 
-    const brackets = config.extra?.brackets
-    const preprocessors = config.extra?.preprocessors
+    // const brackets = config.extra?.brackets
+    // const preprocessors = config.extra?.preprocessors
 
-    await Promise.all([
-      this.processExtraFile(brackets, 'brackets', parsedConfig, configUri),
-      this.processExtraFile(preprocessors, 'preprocessors', parsedConfig, configUri),
-    ])
+    // await Promise.all([
+    //   this.processExtraFile(brackets, 'brackets', parsedConfig, configUri),
+    //   this.processExtraFile(preprocessors, 'preprocessors', parsedConfig, configUri),
+    // ])
   }
 
   private async processExtraFile(

--- a/packages/zenscript/src/workspace/configuration-manager.ts
+++ b/packages/zenscript/src/workspace/configuration-manager.ts
@@ -2,9 +2,9 @@ import { resolve as resolvePath } from 'node:path'
 import type { FileSystemProvider, WorkspaceFolder } from 'langium'
 import { URI, UriUtils } from 'langium'
 import { Resolver } from '@stoplight/json-ref-resolver'
-import { existsDirectory, existsFile, findInside, isDirectory, isFile } from '../utils/fs'
+import { existsDirectory, findInside, isDirectory, isFile } from '../utils/fs'
 import type { ZenScriptSharedServices } from '../module'
-import { ConfigError, DirectoryNotFoundError, EntryError, FileNotFoundError } from '../utils/error'
+import { ConfigError, DirectoryNotFoundError } from '../utils/error'
 import type { ParsedConfig } from './configurations'
 import { IntelliZenSchema, StringConstants } from './configurations'
 
@@ -42,7 +42,7 @@ export class ZenScriptConfigurationManager implements ConfigurationManager {
       }
     }
     else {
-      console.error(new ConfigError(workspaceFolder, { cause: new Error(`Config file "${StringConstants.Config.intellizen}" not found.`) }))
+      console.error(new ConfigError(workspaceFolder, { cause: new Error(`Config file "${StringConstants.File.intellizen}" not found.`) }))
     }
     await this.makeSureSrcRootsIsNotEmpty(parsedConfig, workspaceUri)
     workspaceFolder.config = parsedConfig
@@ -64,30 +64,13 @@ export class ZenScriptConfigurationManager implements ConfigurationManager {
       }
     }
 
-    // const brackets = config.extra?.brackets
-    // const preprocessors = config.extra?.preprocessors
-
-    // await Promise.all([
-    //   this.processExtraFile(brackets, 'brackets', parsedConfig, configUri),
-    //   this.processExtraFile(preprocessors, 'preprocessors', parsedConfig, configUri),
-    // ])
+    await this.processExtraFile(parsedConfig)
   }
 
-  private async processExtraFile(
-    filePath: string | undefined,
-    key: keyof ParsedConfig['extra'],
-    parsedConfig: ParsedConfig,
-    configUri: URI,
-  ) {
-    if (filePath) {
-      const resolvedPath = resolvePath(configUri.fsPath, '..', filePath)
-      if (existsFile(resolvedPath)) {
-        parsedConfig.extra[key] = URI.file(resolvedPath)
-      }
-      else {
-        console.error(new EntryError(`extra.${key}`, { cause: new FileNotFoundError(filePath) }))
-      }
-    }
+  private async processExtraFile(parsedConfig: ParsedConfig) {
+    const nodes = (await Promise.all(parsedConfig.srcRoots.map(srcRoot => this.fileSystemProvider.readDirectory(srcRoot)))).flat()
+    parsedConfig.extra.brackets = nodes.find(it => isFile(it, StringConstants.File.brackets))?.uri
+    parsedConfig.extra.preprocessors = nodes.find(it => isFile(it, StringConstants.File.preprocessors))?.uri
   }
 
   private async makeSureSrcRootsIsNotEmpty(parsedConfig: ParsedConfig, workspaceUri: URI) {
@@ -111,6 +94,6 @@ export class ZenScriptConfigurationManager implements ConfigurationManager {
 
   private async findConfig(workspaceFolder: WorkspaceFolder): Promise<URI | undefined> {
     const workspaceUri = URI.parse(workspaceFolder.uri)
-    return findInside(this.fileSystemProvider, workspaceUri, node => isFile(node, StringConstants.Config.intellizen))
+    return findInside(this.fileSystemProvider, workspaceUri, node => isFile(node, StringConstants.File.intellizen))
   }
 }

--- a/packages/zenscript/src/workspace/configurations.ts
+++ b/packages/zenscript/src/workspace/configurations.ts
@@ -2,21 +2,19 @@ import z from 'zod'
 import type { URI } from 'langium'
 
 export const StringConstants = Object.freeze({
-  Config: {
-    intellizen: 'intellizen.json',
-  },
   Folder: {
     scripts: 'scripts',
     dzs_scripts: 'dzs_scripts',
+  },
+  File: {
+    intellizen: 'intellizen.json',
+    brackets: 'brackets.json',
+    preprocessors: 'preprocessors.json',
   },
 })
 
 export const IntelliZenSchema = z.object({
   srcRoots: z.string().array(),
-  extra: z.object({
-    brackets: z.string().optional(),
-    preprocessors: z.string().optional(),
-  }).optional(),
 })
 
 export type IntelliZenConfig = z.infer<typeof IntelliZenSchema>

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -530,10 +530,6 @@ interface CompoundTypeReference extends TypeReference {
     values: TypeReference[];
 }
 
-interface PrimitiveTypeReference extends TypeReference {
-    value: 'any' | 'byte' | 'short' | 'int' | 'long' | 'float' | 'double' | 'bool' | 'void' | 'string';
-}
-
 interface ListTypeReference extends TypeReference {
     value: TypeReference;
 }

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -44,7 +44,7 @@ interface ValueParameter extends Declaration {
     varargs?: boolean;
     name: string;
     typeRef?: TypeReference;
-    defaultValue?: Expression;
+    defaultValue?: 'default' | Expression;
 }
 
 interface FunctionDeclaration extends Declaration {
@@ -98,7 +98,7 @@ FieldDeclaration returns FieldDeclaration:
 ;
 
 ValueParameter returns ValueParameter:
-    (varargs?='...')? name=ID ('as' typeRef=TypeReference)? ('=' defaultValue=Expression)?
+    (varargs?='...')? name=ID ('as' typeRef=TypeReference)? ('=' defaultValue=('default' | Expression))?
 ;
 
 FunctionDeclaration returns FunctionDeclaration:
@@ -623,6 +623,7 @@ ID returns string
     | 'extends'  // dzs
     | 'operator' // dzs
     | 'for_in'   // dzs
+    | 'default'  // dzs
     | 'orderly'  // zenutils
     | 'any'      // zenclass
     | 'byte'     // zenclass

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -13,7 +13,7 @@ entry Script:
 interface Declaration {}
 
 interface PackageDeclaration extends Declaration {
-    path: @NamedElement[];
+    path: string[];
 }
 
 interface ImportDeclaration extends Declaration {
@@ -75,7 +75,7 @@ interface ConstructorDeclaration extends Declaration {
 }
 
 PackageDeclaration returns PackageDeclaration:
-    'package' (path+=[NamedElement:ID] '.')* path+=[NamedElement:ID] ';'
+    'package' (path+=ID '.')* path+=ID ';'
 ;
 
 ImportDeclaration returns ImportDeclaration:
@@ -611,7 +611,7 @@ ClassType returns ClassTypeReference:
 // Soft keywords
 ID returns string
     : IDENTIFIER
-    | 'in'
+    | 'to'
     | 'extends'  // dzs
     | 'operator' // dzs
     | 'for_in'   // dzs
@@ -633,7 +633,7 @@ terminal IDENTIFIER: /[_a-zA-Z][\w_]*/;
 terminal FLOATING: /[0-9]+\.[0-9]+([eE][+-]?[0-9]+)?[fFdD]?/;
 terminal INTEGER: /(0[xX][0-9a-fA-F]+|[0-9]+)[lL]?/;
 terminal STRING: /"(\\.|[^"\\])*"|'(\\.|[^'\\])*'/;
-terminal BRACKETS: /<[^<>]+>/;
+terminal BRACKETS: /<[^<>\n]+>/;
 
 hidden terminal BLOCK_COMMENT: /\/\*.*?\*\//;
 hidden terminal LINE_COMMENT: /\/\/[^\n\r]*/;

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -588,15 +588,11 @@ ComplexType returns TypeReference:
 ;
 
 fragment PrimaryType returns TypeReference:
-    PrimitiveType | ListType | FunctionType | ParenthesizedType | ClassType
+    ListType | FunctionType | ParenthesizedType | ClassType
 ;
 
 ParenthesizedType returns ParenthesizedTypeReference:
     '(' value=TypeReference ')'
-;
-
-PrimitiveType returns PrimitiveTypeReference:
-    value=('any'| 'byte'| 'short'| 'int'| 'long'| 'float'| 'double'| 'bool'| 'void'| 'string')
 ;
 
 ListType returns ListTypeReference:
@@ -625,16 +621,6 @@ ID returns string
     | 'for_in'   // dzs
     | 'default'  // dzs
     | 'orderly'  // zenutils
-    | 'any'      // zenclass
-    | 'byte'     // zenclass
-    | 'short'    // zenclass
-    | 'int'      // zenclass
-    | 'long'     // zenclass
-    | 'float'    // zenclass
-    | 'double'   // zenclass
-    | 'bool'     // zenclass
-    | 'void'     // zenclass
-    | 'string'   // zenclass
 ;
 
 hidden terminal WHITE_SPACE: /\s+/;

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -48,7 +48,7 @@ interface ValueParameter extends Declaration {
 }
 
 interface FunctionDeclaration extends Declaration {
-    prefix?: 'static' | 'global';
+    prefix?: 'static' | 'global' | 'lambda';
     name: string;
     parameters: ValueParameter[];
     returnTypeRef?: TypeReference;
@@ -102,7 +102,7 @@ ValueParameter returns ValueParameter:
 ;
 
 FunctionDeclaration returns FunctionDeclaration:
-    prefix=('static' | 'global')? 'function' name=ID? '('
+    prefix=('static' | 'global' | 'lambda')? 'function' name=ID '('
         (parameters+=ValueParameter (',' parameters+=ValueParameter)*)?
     ')' ('as' returnTypeRef=TypeReference)? ('{'
         (body+=Statement)*

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -1,6 +1,7 @@
 grammar ZenScript
 
 entry Script:
+    package=PackageDeclaration?
     ( imports+=ImportDeclaration
     | functions+=FunctionDeclaration
     | expands+=ExpandFunctionDeclaration
@@ -10,6 +11,10 @@ entry Script:
 ;
 
 interface Declaration {}
+
+interface PackageDeclaration extends Declaration {
+    path: @NamedElement[];
+}
 
 interface ImportDeclaration extends Declaration {
     path: @NamedElement[];
@@ -24,7 +29,7 @@ interface ClassDeclaration extends Declaration {
 
 type NamedElement = Script | ClassDeclaration | FunctionDeclaration | ExpandFunctionDeclaration | FieldDeclaration | ValueParameter| VariableDeclaration | ForVariableDeclaration | MapEntry | ImportDeclaration;
 
-type ClassMemberDeclaration = FunctionDeclaration | FieldDeclaration | ConstructorDeclaration;
+type ClassMemberDeclaration = FunctionDeclaration | FieldDeclaration | ConstructorDeclaration | OperatorFunctionDeclaration;
 
 type CallableDeclaration = FunctionDeclaration | ExpandFunctionDeclaration | ConstructorDeclaration;
 
@@ -58,10 +63,20 @@ interface ExpandFunctionDeclaration extends Declaration {
     body: Statement[];
 }
 
+interface OperatorFunctionDeclaration extends Declaration {
+    op: string
+    parameters: ValueParameter[];
+    returnTypeRef?: TypeReference;
+}
+
 interface ConstructorDeclaration extends Declaration {
     parameters: ValueParameter[];
     body: Statement[];
 }
+
+PackageDeclaration returns PackageDeclaration:
+    'package' (path+=[NamedElement:ID] '.')* path+=[NamedElement:ID] ';'
+;
 
 ImportDeclaration returns ImportDeclaration:
     'import' (path+=[NamedElement:ID] '.')* path+=[NamedElement:ID] ('as' alias=ID)? ';'?
@@ -76,7 +91,7 @@ ClassDeclaration returns ClassDeclaration:
 ;
 
 ClassMemberDeclaration returns ClassMemberDeclaration:
-    FunctionDeclaration | FieldDeclaration | ConstructorDeclaration;
+    FunctionDeclaration | FieldDeclaration | ConstructorDeclaration | OperatorFunctionDeclaration;
 
 FieldDeclaration returns FieldDeclaration:
     prefix=('static'|'var'|'val') name=ID ('as' typeRef=TypeReference)? ('=' initializer=Expression)? ';'
@@ -89,9 +104,9 @@ ValueParameter returns ValueParameter:
 FunctionDeclaration returns FunctionDeclaration:
     prefix=('static' | 'global')? 'function' name=ID '('
         (parameters+=ValueParameter (',' parameters+=ValueParameter)*)?
-    ')' ('as' returnTypeRef=TypeReference)? '{'
+    ')' ('as' returnTypeRef=TypeReference)? ('{'
         (body+=Statement)*
-    '}'
+    '}')? ';'?
 ;
 
 ExpandFunctionDeclaration returns ExpandFunctionDeclaration:
@@ -100,6 +115,16 @@ ExpandFunctionDeclaration returns ExpandFunctionDeclaration:
     ')' ('as' returnTypeRef=TypeReference)? '{'
         (body+=Statement)*
     '}'
+;
+
+OperatorFunctionDeclaration returns OperatorFunctionDeclaration:
+    'operator' op=Operator '('
+        (parameters+=ValueParameter (',' parameters+=ValueParameter)*)?
+    ')' ('as' returnTypeRef=TypeReference)? ';'?
+;
+
+Operator returns string:
+    '+' | '-' | '*' | '/' | '%' | '~' | '|' | '&' | '^' | '!' | '['']' | '['']''=' | '..' | 'has' | '.' | '.''=' | 'for_in' | 'as' | '==' | '!=' | '<' | '<=' | '>' | '>='
 ;
 
 ConstructorDeclaration returns ConstructorDeclaration:
@@ -591,6 +616,16 @@ ID returns string
     | 'operator' // dzs
     | 'for_in'   // dzs
     | 'orderly'  // zenutils
+    | 'any'      // zenclass
+    | 'byte'     // zenclass
+    | 'short'    // zenclass
+    | 'int'      // zenclass
+    | 'long'     // zenclass
+    | 'float'    // zenclass
+    | 'double'   // zenclass
+    | 'bool'     // zenclass
+    | 'void'     // zenclass
+    | 'string'   // zenclass
 ;
 
 hidden terminal WHITE_SPACE: /\s+/;

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -102,7 +102,7 @@ ValueParameter returns ValueParameter:
 ;
 
 FunctionDeclaration returns FunctionDeclaration:
-    prefix=('static' | 'global' | 'lambda')? 'function' name=ID '('
+    prefix=('static' | 'global' | 'lambda')? 'function' name=ID? '('
         (parameters+=ValueParameter (',' parameters+=ValueParameter)*)?
     ')' ('as' returnTypeRef=TypeReference)? ('{'
         (body+=Statement)*

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -102,7 +102,7 @@ ValueParameter returns ValueParameter:
 ;
 
 FunctionDeclaration returns FunctionDeclaration:
-    prefix=('static' | 'global')? 'function' name=ID '('
+    prefix=('static' | 'global')? 'function' name=ID? '('
         (parameters+=ValueParameter (',' parameters+=ValueParameter)*)?
     ')' ('as' returnTypeRef=TypeReference)? ('{'
         (body+=Statement)*
@@ -120,7 +120,7 @@ ExpandFunctionDeclaration returns ExpandFunctionDeclaration:
 OperatorFunctionDeclaration returns OperatorFunctionDeclaration:
     'operator' op=Operator '('
         (parameters+=ValueParameter (',' parameters+=ValueParameter)*)?
-    ')' ('as' returnTypeRef=TypeReference)? ';'?
+    ')' ('as' returnTypeRef=CompoundType)? ';'?
 ;
 
 Operator returns string:
@@ -526,6 +526,10 @@ interface IntersectionTypeReference extends TypeReference {
     values: TypeReference[];
 }
 
+interface CompoundTypeReference extends TypeReference {
+    values: TypeReference[];
+}
+
 interface PrimitiveTypeReference extends TypeReference {
     value: 'any' | 'byte' | 'short' | 'int' | 'long' | 'float' | 'double' | 'bool' | 'void' | 'string';
 }
@@ -570,6 +574,10 @@ UnionType returns TypeReference:
 
 IntersectionType returns TypeReference:
     ComplexType ({IntersectionTypeReference.values+=current} ('&' values+=ComplexType)+)?
+;
+
+CompoundType returns TypeReference:
+    ComplexType ({CompoundTypeReference.values+=current} (',' values+=ComplexType)+)?
 ;
 
 ComplexType returns TypeReference:

--- a/packages/zenscript/test/grammar/expr.test.ts
+++ b/packages/zenscript/test/grammar/expr.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { assertNoErrors, assertReferenceExpressionText, assertTypeRef, createParseHelper } from '../utils'
+import { assertClassTypeReference, assertNoErrors, assertReferenceExpressionText, createParseHelper } from '../utils'
 import type { ArrayAccess, ArrayLiteral, Assignment, BooleanLiteral, CallExpression, ConditionalExpression, Expression, ExpressionStatement, FunctionExpression, InfixExpression, InstanceofExpression, MapLiteral, MemberAccess, NullLiteral, NumberLiteral, ParenthesizedExpression, PrefixExpression, ReferenceExpression, StringLiteral, StringTemplate, TypeCastExpression } from '../../src/generated/ast'
 
 const parse = createParseHelper()
@@ -158,8 +158,8 @@ describe('parse expression of script with ZenScript ', () => {
     expect(functionExpr.parameters.length).toBe(1)
     const foo = functionExpr.parameters[0]
     expect(foo.name).toBe('foo')
-    assertTypeRef('int', foo.typeRef)
-    assertTypeRef('void', functionExpr.returnTypeRef)
+    assertClassTypeReference(foo.typeRef, 'int')
+    assertClassTypeReference(functionExpr.returnTypeRef, 'void')
   })
 
   it('call expression', async () => {
@@ -208,9 +208,9 @@ describe('parse expression of script with ZenScript ', () => {
     const [int, otherType] = typeCastExpr
 
     assertReferenceExpressionText(int.expr, 'foo')
-    assertTypeRef('int', int.typeRef)
+    assertClassTypeReference(int.typeRef, 'int')
     assertReferenceExpressionText(otherType.expr, 'bar')
-    assertTypeRef(['OtherType'], otherType.typeRef)
+    assertClassTypeReference(otherType.typeRef, 'OtherType')
   })
 
   it('array access', async () => {
@@ -222,7 +222,7 @@ describe('parse expression of script with ZenScript ', () => {
   it('instanceof expression', async () => {
     const instanceofExpr = await parseExpr<InstanceofExpression>('foo instanceof int;')
     assertReferenceExpressionText(instanceofExpr.expr, 'foo')
-    assertTypeRef('int', instanceofExpr.typeRef)
+    assertClassTypeReference(instanceofExpr.typeRef, 'int')
   })
 
   it('operator priority', async () => {

--- a/packages/zenscript/test/grammar/expr.test.ts
+++ b/packages/zenscript/test/grammar/expr.test.ts
@@ -150,7 +150,10 @@ describe('parse expression of script with ZenScript ', () => {
   })
 
   it('function expression', async () => {
-    const functionExpr = await parseExpr<FunctionExpression>('function (foo as int) as void {};')
+    const expr = await parseExpr<ParenthesizedExpression>('(function (foo as int) as void {});')
+    expect(expr.$type).toBe('ParenthesizedExpression')
+
+    const functionExpr = expr.expr as FunctionExpression
     expect(functionExpr.$type).toBe('FunctionExpression')
     expect(functionExpr.parameters.length).toBe(1)
     const foo = functionExpr.parameters[0]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@stoplight/json-ref-resolver':
+        specifier: ^3.1.6
+        version: 3.1.6
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -720,6 +723,26 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
+  '@stoplight/json-ref-resolver@3.1.6':
+    resolution: {integrity: sha512-YNcWv3R3n3U6iQYBsFOiWSuRGE5su1tJSiX6pAPRVk7dP0L7lqCteXGzuVRQ0gMZqUl8v1P0+fAKxF6PLo9B5A==}
+    engines: {node: '>=8.3.0'}
+
+  '@stoplight/json@3.21.7':
+    resolution: {integrity: sha512-xcJXgKFqv/uCEgtGlPxy3tPA+4I+ZI4vAuMJ885+ThkTHFVkC+0Fm58lA9NlsyjnkpxFh4YiQWpH+KefHdbA0A==}
+    engines: {node: '>=8.3.0'}
+
+  '@stoplight/ordered-object-literal@1.0.5':
+    resolution: {integrity: sha512-COTiuCU5bgMUtbIFBuyyh2/yVVzlr5Om0v5utQDgBCuQUOPgU1DwoffkTfg4UBQOvByi5foF4w4T+H9CoRe5wg==}
+    engines: {node: '>=8'}
+
+  '@stoplight/path@1.3.2':
+    resolution: {integrity: sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==}
+    engines: {node: '>=8'}
+
+  '@stoplight/types@13.20.0':
+    resolution: {integrity: sha512-2FNTv05If7ib79VPDA/r9eUet76jewXFH2y2K5vuge6SXbRHtWBhcaRmu+6QpF4/WRNoJj5XYRSwLGXDxysBGA==}
+    engines: {node: ^12.20 || >=14.13}
+
   '@stylistic/eslint-plugin-js@2.6.4':
     resolution: {integrity: sha512-kx1hS3xTvzxZLdr/DCU/dLBE++vcP97sHeEFX2QXhk1Ipa4K1rzPOLw1HCbf4mU3s+7kHP5eYpDe+QteEOFLug==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -772,6 +795,9 @@ packages:
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/urijs@1.19.25':
+    resolution: {integrity: sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==}
 
   '@types/vscode@1.92.0':
     resolution: {integrity: sha512-DcZoCj17RXlzB4XJ7IfKdPTcTGDLYvTOcTNkvtjXWF+K2TlKzHHkBEXNWQRpBIXixNEUgx39cQeTFunY0E2msw==}
@@ -1284,6 +1310,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dependency-graph@0.11.0:
+    resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
+    engines: {node: '>= 0.6.0'}
+
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
@@ -1596,6 +1626,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-memoize@2.5.2:
+    resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
+
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -1788,6 +1821,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immer@9.0.21:
+    resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
+
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -1926,6 +1962,9 @@ packages:
   jsonc-eslint-parser@2.4.0:
     resolution: {integrity: sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  jsonc-parser@2.2.1:
+    resolution: {integrity: sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==}
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -2485,6 +2524,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-stable-stringify@1.1.1:
+    resolution: {integrity: sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2851,11 +2893,18 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  urijs@1.19.11:
+    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
+
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -3555,6 +3604,37 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
+  '@stoplight/json-ref-resolver@3.1.6':
+    dependencies:
+      '@stoplight/json': 3.21.7
+      '@stoplight/path': 1.3.2
+      '@stoplight/types': 13.20.0
+      '@types/urijs': 1.19.25
+      dependency-graph: 0.11.0
+      fast-memoize: 2.5.2
+      immer: 9.0.21
+      lodash: 4.17.21
+      tslib: 2.6.3
+      urijs: 1.19.11
+
+  '@stoplight/json@3.21.7':
+    dependencies:
+      '@stoplight/ordered-object-literal': 1.0.5
+      '@stoplight/path': 1.3.2
+      '@stoplight/types': 13.20.0
+      jsonc-parser: 2.2.1
+      lodash: 4.17.21
+      safe-stable-stringify: 1.1.1
+
+  '@stoplight/ordered-object-literal@1.0.5': {}
+
+  '@stoplight/path@1.3.2': {}
+
+  '@stoplight/types@13.20.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      utility-types: 3.11.0
+
   '@stylistic/eslint-plugin-js@2.6.4(eslint@9.9.0)':
     dependencies:
       '@types/eslint': 9.6.0
@@ -3625,6 +3705,8 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/unist@2.0.11': {}
+
+  '@types/urijs@1.19.25': {}
 
   '@types/vscode@1.92.0': {}
 
@@ -4221,6 +4303,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dependency-graph@0.11.0: {}
+
   detect-libc@2.0.3:
     optional: true
 
@@ -4678,6 +4762,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-memoize@2.5.2: {}
+
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -4870,6 +4956,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immer@9.0.21: {}
+
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -4984,6 +5072,8 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       semver: 7.6.3
+
+  jsonc-parser@2.2.1: {}
 
   jsonc-parser@3.3.1: {}
 
@@ -5576,6 +5666,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-stable-stringify@1.1.1: {}
+
   safer-buffer@2.1.2: {}
 
   sax@1.4.1: {}
@@ -5920,9 +6012,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  urijs@1.19.11: {}
+
   url-join@4.0.1: {}
 
   util-deprecate@1.0.2: {}
+
+  utility-types@3.11.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
The ".dzs" file is used to provide ZenScript type information about an API that's written in Java.
Inspired by ".d.ts" from TypeScript.