### PR TITLE
feat: unquoted string

### DIFF
--- a/packages/zenscript/src/typing/type-computer.ts
+++ b/packages/zenscript/src/typing/type-computer.ts
@@ -361,6 +361,10 @@ export class ZenScriptTypeComputer implements TypeComputer {
       return this.classTypeOf('string')
     })
 
+    rule('UnquotedString', (_) => {
+      return this.classTypeOf('string')
+    })
+
     rule('StringTemplate', (_) => {
       return this.classTypeOf('string')
     })

--- a/packages/zenscript/src/zenscript.langium
+++ b/packages/zenscript/src/zenscript.langium
@@ -352,6 +352,10 @@ interface StringLiteral extends Expression {
     value: string;
 }
 
+interface UnquotedString extends Expression {
+    value: string;
+}
+
 interface NullLiteral extends Expression {
     value: 'null';
 }
@@ -473,7 +477,7 @@ MapLiteral returns MapLiteral:
 ;
 
 MapEntry returns MapEntry:
-    key=Expression ':' value=Expression
+    key=(UnquotedString | Expression) ':' value=Expression
 ;
 
 ReferenceExpression returns ReferenceExpression:
@@ -498,6 +502,10 @@ BooleanLiteral returns BooleanLiteral:
 
 StringLiteral returns StringLiteral:
     value=STRING
+;
+
+UnquotedString returns UnquotedString:
+    value=ID
 ;
 
 NullLiteral returns NullLiteral:

--- a/packages/zenscript/test/typing/unquoted-string/intellizen.json
+++ b/packages/zenscript/test/typing/unquoted-string/intellizen.json
@@ -1,0 +1,5 @@
+{
+  "srcRoots": [
+    "./scripts"
+  ]
+}

--- a/packages/zenscript/test/typing/unquoted-string/scripts/map.zs
+++ b/packages/zenscript/test/typing/unquoted-string/scripts/map.zs
@@ -1,0 +1,1 @@
+val map = { UnquotedString: "QuotedString" };

--- a/packages/zenscript/test/typing/unquoted-string/unquoted-string.test.ts
+++ b/packages/zenscript/test/typing/unquoted-string/unquoted-string.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { assertNoErrors, createTestServices, getDocument } from '../../utils'
+import type { MapLiteral, UnquotedString, VariableDeclaration } from '../../../src/generated/ast'
+
+const services = await createTestServices(__dirname)
+
+describe(`check unquoted string in map literal`, async () => {
+  const document_map_zs = await getDocument(services, path.resolve(__dirname, 'scripts', 'map.zs'))
+  const script_map_zs = document_map_zs.parseResult.value
+  const statement_val_map = script_map_zs.statements[0] as VariableDeclaration
+  const expression_map_literal = statement_val_map.initializer as MapLiteral
+
+  it('should no errors', () => {
+    assertNoErrors(document_map_zs)
+  })
+
+  it('check inferring unquoted string', () => {
+    const unquotedString = expression_map_literal.entries[0].key as UnquotedString
+    const type = services.typing.TypeComputer.inferType(unquotedString)
+    expect(type?.toString()).toBe('string')
+  })
+})


### PR DESCRIPTION
A unquoted string may appear in a map literal expression. For example:

```zenscript
val map = { UnquotedString: "QuotedString" } as string[string];
```