### PR TITLE
feat: synthetic ast node

### DIFF
--- a/packages/zenscript/src/builtins/any.dzs
+++ b/packages/zenscript/src/builtins/any.dzs
@@ -1,1 +1,3 @@
-zenClass any
+zenClass any {
+    operator .(target as any) as any;
+}

--- a/packages/zenscript/src/module.ts
+++ b/packages/zenscript/src/module.ts
@@ -7,6 +7,7 @@ import { CustomTokenBuilder } from './lexer/token-builder'
 import { CustomValueConverter } from './lexer/value-converter'
 import { ZenScriptCompletionProvider } from './lsp/completion-provider'
 import { ZenScriptInlayHintProvider } from './lsp/inlay-hint-provider'
+import { ZenScriptLinker } from './reference/linker'
 import { ZenScriptMemberProvider } from './reference/member-provider'
 import { ZenScriptNameProvider } from './reference/name-provider'
 import { ZenScriptScopeComputation } from './reference/scope-computation'
@@ -64,6 +65,7 @@ export const ZenScriptModule: Module<ZenScriptServices, PartialLangiumServices &
     ScopeComputation: services => new ZenScriptScopeComputation(services),
     ScopeProvider: services => new ZenScriptScopeProvider(services),
     MemberProvider: services => new ZenScriptMemberProvider(services),
+    Linker: services => new ZenScriptLinker(services),
   },
   workspace: {
     PackageManager: services => new ZenScriptPackageManager(services),

--- a/packages/zenscript/src/reference/linker.ts
+++ b/packages/zenscript/src/reference/linker.ts
@@ -6,7 +6,7 @@ import { DefaultLinker, stream } from 'langium'
 import { isOperatorFunctionDeclaration } from '../generated/ast'
 
 type SourceMap = ZenScriptAstType
-type RuleMap = { [K in keyof SourceMap]?: (source: ReferenceInfo & { container: SourceMap[K] }) => AstNodeDescription | undefined }
+type SyntheticRuleMap = { [K in keyof SourceMap]?: (source: ReferenceInfo & { container: SourceMap[K] }) => AstNodeDescription | undefined }
 
 export class ZenScriptLinker extends DefaultLinker {
   private readonly memberProvider: MemberProvider
@@ -26,10 +26,10 @@ export class ZenScriptLinker extends DefaultLinker {
 
   private getSynthetic(refInfo: ReferenceInfo): AstNodeDescription | undefined {
     // @ts-expect-error allowed index type
-    return this.rules[refInfo.container.$type]?.call(this, refInfo)
+    return this.syntheticRules[refInfo.container.$type]?.call(this, refInfo)
   }
 
-  private readonly rules: RuleMap = {
+  private readonly syntheticRules: SyntheticRuleMap = {
     MemberAccess: (source) => {
       return stream(this.memberProvider.getMember(source.container.receiver))
         .map(it => it.node)

--- a/packages/zenscript/src/reference/linker.ts
+++ b/packages/zenscript/src/reference/linker.ts
@@ -1,0 +1,39 @@
+import type { AstNodeDescription, LinkingError, ReferenceInfo } from 'langium'
+import type { ZenScriptAstType } from '../generated/ast'
+import type { ZenScriptServices } from '../module'
+import type { TypeComputer } from '../typing/type-computer'
+import { DefaultLinker } from 'langium'
+import { isAnyType } from '../typing/type-description'
+import { createSyntheticAstNodeDescription } from './synthetic'
+
+type SourceMap = ZenScriptAstType
+type RuleMap = { [K in keyof SourceMap]?: (source: ReferenceInfo & { container: SourceMap[K] }) => AstNodeDescription | undefined }
+
+export class ZenScriptLinker extends DefaultLinker {
+  private readonly typeComputer: TypeComputer
+
+  constructor(services: ZenScriptServices) {
+    super(services)
+    this.typeComputer = services.typing.TypeComputer
+  }
+
+  override getCandidate(refInfo: ReferenceInfo): AstNodeDescription | LinkingError {
+    const scope = this.scopeProvider.getScope(refInfo)
+    const description = scope.getElement(refInfo.reference.$refText) ?? this.getSynthetic(refInfo)
+    return description ?? this.createLinkingError(refInfo)
+  }
+
+  private getSynthetic(refInfo: ReferenceInfo): AstNodeDescription | undefined {
+    // @ts-expect-error allowed index type
+    return this.rules[refInfo.container.$type]?.call(this, refInfo)
+  }
+
+  private readonly rules: RuleMap = {
+    MemberAccess: (source) => {
+      const receiverType = this.typeComputer.inferType(source.container.receiver)
+      if (isAnyType(receiverType)) {
+        return createSyntheticAstNodeDescription('SyntheticUnknown', source.reference.$refText)
+      }
+    },
+  }
+}

--- a/packages/zenscript/src/reference/member-provider.ts
+++ b/packages/zenscript/src/reference/member-provider.ts
@@ -7,7 +7,7 @@ import { stream } from 'langium'
 import { isVariableDeclaration } from '../generated/ast'
 import { isFunctionType, type Type, type ZenScriptType } from '../typing/type-description'
 import { getClassChain, isStatic } from '../utils/ast'
-import { createSyntheticAstNodeDescription } from './synthetic'
+import { createSyntheticAstNodeDescription, isSyntheticAstNode } from './synthetic'
 
 export interface MemberProvider {
   getMember: (source: AstNode | Type | undefined) => AstNodeDescription[]
@@ -84,7 +84,7 @@ export class ZenScriptMemberProvider implements MemberProvider {
         return []
       }
 
-      if (target.$type as string === 'HierarchyNode') {
+      if (isSyntheticAstNode(target)) {
         return this.getMember(target)
       }
 

--- a/packages/zenscript/src/reference/member-provider.ts
+++ b/packages/zenscript/src/reference/member-provider.ts
@@ -5,7 +5,7 @@ import type { TypeComputer } from '../typing/type-computer'
 import type { ZenScriptSyntheticAstType } from './synthetic'
 import { stream } from 'langium'
 import { isVariableDeclaration } from '../generated/ast'
-import { isAnyType, isFunctionType, type Type, type ZenScriptType } from '../typing/type-description'
+import { isAnyType, isClassType, isFunctionType, type Type, type ZenScriptType } from '../typing/type-description'
 import { getClassChain, isStatic } from '../utils/ast'
 import { createSyntheticAstNodeDescription, isSyntheticAstNode } from './synthetic'
 
@@ -93,7 +93,10 @@ export class ZenScriptMemberProvider implements MemberProvider {
         return this.getMember(target)
       }
 
-      const type = this.typeComputer.inferType(source)
+      let type = this.typeComputer.inferType(source)
+      if (isClassType(receiverType)) {
+        type = type?.substituteTypeParameters(receiverType.substitutions)
+      }
       return this.getMember(type)
     },
 

--- a/packages/zenscript/src/reference/member-provider.ts
+++ b/packages/zenscript/src/reference/member-provider.ts
@@ -111,6 +111,11 @@ export class ZenScriptMemberProvider implements MemberProvider {
       return isFunctionType(receiverType) ? this.getMember(receiverType.returnType) : []
     },
 
+    BracketExpression: (source) => {
+      const type = this.typeComputer.inferType(source)
+      return this.getMember(type)
+    },
+
     FieldDeclaration: (source) => {
       const type = this.typeComputer.inferType(source)
       return this.getMember(type)

--- a/packages/zenscript/src/reference/member-provider.ts
+++ b/packages/zenscript/src/reference/member-provider.ts
@@ -5,7 +5,7 @@ import type { TypeComputer } from '../typing/type-computer'
 import type { ZenScriptSyntheticAstType } from './synthetic'
 import { stream } from 'langium'
 import { isVariableDeclaration } from '../generated/ast'
-import { isFunctionType, type Type, type ZenScriptType } from '../typing/type-description'
+import { isAnyType, isFunctionType, type Type, type ZenScriptType } from '../typing/type-description'
 import { getClassChain, isStatic } from '../utils/ast'
 import { createSyntheticAstNodeDescription, isSyntheticAstNode } from './synthetic'
 
@@ -108,7 +108,13 @@ export class ZenScriptMemberProvider implements MemberProvider {
 
     CallExpression: (source) => {
       const receiverType = this.typeComputer.inferType(source.receiver)
-      return isFunctionType(receiverType) ? this.getMember(receiverType.returnType) : []
+      if (isFunctionType(receiverType)) {
+        return this.getMember(receiverType.returnType)
+      }
+      if (isAnyType(receiverType)) {
+        return this.getMember(receiverType)
+      }
+      return []
     },
 
     BracketExpression: (source) => {

--- a/packages/zenscript/src/reference/scope-provider.ts
+++ b/packages/zenscript/src/reference/scope-provider.ts
@@ -6,8 +6,9 @@ import type { MemberProvider } from './member-provider'
 import { substringBeforeLast } from '@intellizen/shared'
 import { AstUtils, DefaultScopeProvider, EMPTY_SCOPE, stream } from 'langium'
 import { ClassDeclaration, ImportDeclaration, isClassDeclaration, TypeParameter } from '../generated/ast'
-import { createHierarchyNodeDescription, getPathAsString } from '../utils/ast'
+import { getPathAsString } from '../utils/ast'
 import { generateStream } from '../utils/stream'
+import { createSyntheticAstNodeDescription } from './synthetic'
 
 type SourceMap = ZenScriptAstType
 type RuleMap = { [K in keyof SourceMap]?: (source: ReferenceInfo & { container: SourceMap[K] }) => Scope }
@@ -55,7 +56,7 @@ export class ZenScriptScopeProvider extends DefaultScopeProvider {
           sibling.data.forEach(it => elements.push(this.descriptions.createDescription(it, sibling.name)))
         }
         else {
-          elements.push(createHierarchyNodeDescription(sibling))
+          elements.push(createSyntheticAstNodeDescription('SyntheticHierarchyNode', sibling.name, sibling))
         }
       }
       return this.createScope(elements)
@@ -66,7 +67,7 @@ export class ZenScriptScopeProvider extends DefaultScopeProvider {
 
       const packages: Stream<AstNodeDescription> = stream(this.packageManager.root.children.values())
         .filter(it => it.isInternalNode())
-        .map(it => createHierarchyNodeDescription(it))
+        .map(it => createSyntheticAstNodeDescription('SyntheticHierarchyNode', it.name, it))
       outer = this.createScope(packages)
 
       const globals = this.indexManager.allElements()

--- a/packages/zenscript/src/reference/synthetic.ts
+++ b/packages/zenscript/src/reference/synthetic.ts
@@ -1,0 +1,27 @@
+import type { HierarchyNode } from '@intellizen/shared'
+import type { AstNode, AstNodeDescription } from 'langium'
+import { URI } from 'langium'
+
+export interface ZenScriptSyntheticAstType {
+  SyntheticHierarchyNode: HierarchyNode<AstNode>
+  SyntheticUnknown: AstNode
+  SyntheticString: AstNode
+}
+
+export function createSyntheticAstNodeDescription<K extends keyof ZenScriptSyntheticAstType>(
+  $type: K,
+  name: string,
+  origin?: ZenScriptSyntheticAstType[K],
+): AstNodeDescription {
+  return {
+    node: createSyntheticAstNode($type, origin),
+    type: $type,
+    name,
+    documentUri: URI.from({ scheme: 'synthetic', path: `/${$type}/${name}` }),
+    path: '',
+  }
+}
+
+export function createSyntheticAstNode($type: string, origin?: any): AstNode {
+  return { $type, ...origin }
+}

--- a/packages/zenscript/src/reference/synthetic.ts
+++ b/packages/zenscript/src/reference/synthetic.ts
@@ -4,8 +4,6 @@ import { URI } from 'langium'
 
 export interface ZenScriptSyntheticAstType {
   SyntheticHierarchyNode: HierarchyNode<AstNode>
-  SyntheticUnknown: AstNode
-  SyntheticString: AstNode
 }
 
 export function createSyntheticAstNodeDescription<K extends keyof ZenScriptSyntheticAstType>(

--- a/packages/zenscript/src/reference/synthetic.ts
+++ b/packages/zenscript/src/reference/synthetic.ts
@@ -3,7 +3,7 @@ import type { AstNode, AstNodeDescription } from 'langium'
 import { URI } from 'langium'
 
 export interface ZenScriptSyntheticAstType {
-  SyntheticHierarchyNode: AstNode & HierarchyNode<AstNode>
+  SyntheticHierarchyNode: HierarchyNode<AstNode>
 }
 
 export function createSyntheticAstNodeDescription<K extends keyof ZenScriptSyntheticAstType>(

--- a/packages/zenscript/src/reference/synthetic.ts
+++ b/packages/zenscript/src/reference/synthetic.ts
@@ -25,3 +25,7 @@ export function createSyntheticAstNodeDescription<K extends keyof ZenScriptSynth
 export function createSyntheticAstNode($type: string, origin?: any): AstNode {
   return { $type, ...origin }
 }
+
+export function isSyntheticAstNode(node: AstNode): boolean {
+  return node?.$type?.startsWith('Synthetic')
+}

--- a/packages/zenscript/src/reference/synthetic.ts
+++ b/packages/zenscript/src/reference/synthetic.ts
@@ -3,7 +3,7 @@ import type { AstNode, AstNodeDescription } from 'langium'
 import { URI } from 'langium'
 
 export interface ZenScriptSyntheticAstType {
-  SyntheticHierarchyNode: HierarchyNode<AstNode>
+  SyntheticHierarchyNode: AstNode & HierarchyNode<AstNode>
 }
 
 export function createSyntheticAstNodeDescription<K extends keyof ZenScriptSyntheticAstType>(

--- a/packages/zenscript/src/typing/type-computer.ts
+++ b/packages/zenscript/src/typing/type-computer.ts
@@ -42,10 +42,6 @@ export class ZenScriptTypeComputer implements TypeComputer {
   }
 
   private readonly rules: RuleMap = {
-    SyntheticUnknown: (_) => {
-      return this.classTypeOf('any')
-    },
-
     // region TypeReference
     ArrayTypeReference: (source) => {
       const arrayType = this.classTypeOf('Array')
@@ -285,6 +281,11 @@ export class ZenScriptTypeComputer implements TypeComputer {
     },
 
     MemberAccess: (source) => {
+      const targetContainer = source.target.ref?.$container
+      if (isOperatorFunctionDeclaration(targetContainer) && targetContainer.op === '.') {
+        return this.inferType(targetContainer.returnTypeRef)
+      }
+
       const receiverType = this.inferType(source.receiver)
       const memberType = this.inferType(source.target.ref)
       if (memberType && isClassType(receiverType)) {

--- a/packages/zenscript/src/typing/type-computer.ts
+++ b/packages/zenscript/src/typing/type-computer.ts
@@ -6,7 +6,7 @@ import type { PackageManager } from '../workspace/package-manager'
 import type { BuiltinTypes, Type, TypeParameterSubstitutions } from './type-description'
 import { type AstNode, stream } from 'langium'
 import { isAssignment, isCallExpression, isClassDeclaration, isExpression, isFunctionDeclaration, isFunctionExpression, isOperatorFunctionDeclaration, isTypeParameter, isVariableDeclaration } from '../generated/ast'
-import { ClassType, CompoundType, FunctionType, IntersectionType, isClassType, isFunctionType, TypeVariable, UnionType } from './type-description'
+import { ClassType, CompoundType, FunctionType, IntersectionType, isAnyType, isClassType, isFunctionType, TypeVariable, UnionType } from './type-description'
 
 export interface TypeComputer {
   inferType: (node: AstNode | undefined) => Type | undefined
@@ -296,6 +296,10 @@ export class ZenScriptTypeComputer implements TypeComputer {
 
     IndexingExpression: (source) => {
       const receiverType = this.inferType(source.receiver)
+      if (isAnyType(receiverType)) {
+        return receiverType
+      }
+
       const operatorDecl = this.memberProvider().getMember(source.receiver)
         .map(it => it.node)
         .filter(it => isOperatorFunctionDeclaration(it))
@@ -312,6 +316,9 @@ export class ZenScriptTypeComputer implements TypeComputer {
       const receiverType = this.inferType(source.receiver)
       if (isFunctionType(receiverType)) {
         return receiverType.returnType
+      }
+      if (isAnyType(receiverType)) {
+        return receiverType
       }
     },
 

--- a/packages/zenscript/src/typing/type-computer.ts
+++ b/packages/zenscript/src/typing/type-computer.ts
@@ -1,6 +1,7 @@
 import type { ClassDeclaration, ZenScriptAstType } from '../generated/ast'
 import type { ZenScriptServices } from '../module'
 import type { MemberProvider } from '../reference/member-provider'
+import type { ZenScriptSyntheticAstType } from '../reference/synthetic'
 import type { PackageManager } from '../workspace/package-manager'
 import type { BuiltinTypes, Type, TypeParameterSubstitutions } from './type-description'
 import { type AstNode, stream } from 'langium'
@@ -11,7 +12,7 @@ export interface TypeComputer {
   inferType: (node: AstNode | undefined) => Type | undefined
 }
 
-type SourceMap = ZenScriptAstType
+type SourceMap = ZenScriptAstType & ZenScriptSyntheticAstType
 type RuleMap = { [K in keyof SourceMap]?: (source: SourceMap[K]) => Type | undefined }
 
 export class ZenScriptTypeComputer implements TypeComputer {
@@ -41,6 +42,10 @@ export class ZenScriptTypeComputer implements TypeComputer {
   }
 
   private readonly rules: RuleMap = {
+    SyntheticUnknown: (_) => {
+      return this.classTypeOf('any')
+    },
+
     // region TypeReference
     ArrayTypeReference: (source) => {
       const arrayType = this.classTypeOf('Array')

--- a/packages/zenscript/src/utils/ast.ts
+++ b/packages/zenscript/src/utils/ast.ts
@@ -1,7 +1,6 @@
-import type { HierarchyNode } from '@intellizen/shared'
-import type { AstNode, AstNodeDescription, ReferenceInfo } from 'langium'
+import type { AstNode, ReferenceInfo } from 'langium'
 import type { ClassDeclaration, ImportDeclaration } from '../generated/ast'
-import { AstUtils, URI } from 'langium'
+import { AstUtils } from 'langium'
 import { isClassDeclaration, isFunctionDeclaration, isScript } from '../generated/ast'
 import { isZs } from './document'
 
@@ -68,22 +67,4 @@ export function getPathAsString(importDecl: ImportDeclaration, index?: number): 
     names = names.slice(0, index + 1)
   }
   return names.join('.')
-}
-
-export function createHierarchyNodeDescription(node: HierarchyNode<AstNode>): AstNodeDescription {
-  return createSyntheticAstNodeDescription('HierarchyNode', node, node.name)
-}
-
-export function createSyntheticAstNodeDescription(type: string, origin: any, name: string): AstNodeDescription {
-  return {
-    node: createSyntheticAstNode(type, origin),
-    type,
-    name,
-    documentUri: URI.from({ scheme: 'synthetic', path: `/${type}/${name}` }),
-    path: '',
-  }
-}
-
-export function createSyntheticAstNode($type: string, origin: any): AstNode {
-  return { $type, ...origin }
 }

--- a/packages/zenscript/test/typing/synthetic-member/intellizen.json
+++ b/packages/zenscript/test/typing/synthetic-member/intellizen.json
@@ -1,0 +1,5 @@
+{
+  "srcRoots": [
+    "./scripts"
+  ]
+}

--- a/packages/zenscript/test/typing/synthetic-member/scripts/synthetic.zs
+++ b/packages/zenscript/test/typing/synthetic-member/scripts/synthetic.zs
@@ -1,0 +1,2 @@
+val justAny as any;
+justAny.foo.bar;

--- a/packages/zenscript/test/typing/synthetic-member/synthetic-member.test.ts
+++ b/packages/zenscript/test/typing/synthetic-member/synthetic-member.test.ts
@@ -1,0 +1,24 @@
+import type { ExpressionStatement, MemberAccess } from '../../../src/generated/ast'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { assertNoErrors, createTestServices, getDocument } from '../../utils'
+
+const services = await createTestServices(__dirname)
+
+describe(`check synthetic member`, async () => {
+  const document_synthetic_zs = await getDocument(services, path.resolve(__dirname, 'scripts', 'synthetic.zs'))
+  const script_synthetic_zs = document_synthetic_zs.parseResult.value
+  const statement_justAny_foo_bar = script_synthetic_zs.statements[1] as ExpressionStatement
+  const expression_justAny_foo_bar = statement_justAny_foo_bar.expr as MemberAccess
+
+  it('should no errors', () => {
+    assertNoErrors(document_synthetic_zs)
+  })
+
+  it('check inferring synthetic member', () => {
+    const bar = expression_justAny_foo_bar.target.ref
+    const type_bar = services.typing.TypeComputer.inferType(bar)
+    expect(bar).toBeDefined()
+    expect(type_bar?.toString()).toBe('any')
+  })
+})


### PR DESCRIPTION
Member accessing target maybe synthetic. For example:
```zenscript
val justAny as any;
justAny.syntheticMember;
```