### PR TITLE
feat: description index

### DIFF
--- a/packages/zenscript/src/module.ts
+++ b/packages/zenscript/src/module.ts
@@ -17,6 +17,7 @@ import { ZenScriptTypeComputer } from './typing/type-computer'
 import { registerValidationChecks, ZenScriptValidator } from './validation/validator'
 import { ZenScriptBracketManager } from './workspace/bracket-manager'
 import { ZenScriptConfigurationManager } from './workspace/configuration-manager'
+import { ZenScriptDescriptionIndex } from './workspace/description-index'
 import { ZenScriptPackageManager } from './workspace/package-manager'
 import { ZenScriptWorkspaceManager } from './workspace/workspace-manager'
 
@@ -37,6 +38,7 @@ export interface ZenScriptAddedServices {
   workspace: {
     PackageManager: ZenScriptPackageManager
     BracketManager: ZenScriptBracketManager
+    DescriptionIndex: ZenScriptDescriptionIndex
   }
 }
 
@@ -74,6 +76,7 @@ export const ZenScriptModule: Module<ZenScriptServices, PartialLangiumServices &
   workspace: {
     PackageManager: services => new ZenScriptPackageManager(services),
     BracketManager: services => new ZenScriptBracketManager(services),
+    DescriptionIndex: services => new ZenScriptDescriptionIndex(services),
   },
   parser: {
     TokenBuilder: () => new CustomTokenBuilder(),

--- a/packages/zenscript/src/reference/scope-computation.ts
+++ b/packages/zenscript/src/reference/scope-computation.ts
@@ -1,17 +1,33 @@
-import type { AstNode, AstNodeDescription, LangiumDocument } from 'langium'
+import type { AstNode, AstNodeDescription, LangiumDocument, PrecomputedScopes } from 'langium'
 import type { Script } from '../generated/ast'
 import type { ZenScriptServices } from '../module'
+import type { ZenScriptDescriptionIndex } from '../workspace/description-index'
 import { DefaultScopeComputation } from 'langium'
 import { isGlobal } from '../utils/ast'
 
 export class ZenScriptScopeComputation extends DefaultScopeComputation {
+  private readonly descriptionIndex: ZenScriptDescriptionIndex
+
   constructor(services: ZenScriptServices) {
     super(services)
+    this.descriptionIndex = services.workspace.DescriptionIndex
   }
 
   protected override exportNode(node: AstNode, exports: AstNodeDescription[], document: LangiumDocument<Script>): void {
     if (isGlobal(node)) {
       exports.push(this.descriptions.createDescription(node, undefined, document))
+    }
+  }
+
+  protected override processNode(node: AstNode, document: LangiumDocument, scopes: PrecomputedScopes): void {
+    const container = node.$container
+    if (container) {
+      const name = this.nameProvider.getName(node)
+      if (name) {
+        const description = this.descriptions.createDescription(node, name, document)
+        this.descriptionIndex.astDescriptions.set(node, description)
+        scopes.add(container, description)
+      }
     }
   }
 }

--- a/packages/zenscript/src/reference/scope-provider.ts
+++ b/packages/zenscript/src/reference/scope-provider.ts
@@ -70,22 +70,6 @@ export class ZenScriptScopeProvider extends DefaultScopeProvider {
     return this.createScope(classes, outside)
   }
 
-  private importAlias(importDesc: AstNodeDescription) {
-    const importDecl = importDesc.node as ImportDeclaration
-
-    const targetRef = importDecl.path.at(-1)
-    // call ref to ensure the reference is resolved
-    if (!targetRef?.ref) {
-      return importDesc
-    }
-
-    const targetDesc = importDecl.path.at(-1)?.$nodeDescription ?? importDesc
-    if (!importDecl.alias) {
-      return targetDesc
-    }
-    return this.descriptionIndex.createAliasDescription(targetDesc || importDesc, importDecl.alias)
-  }
-
   private readonly rules: RuleMap = {
     ImportDeclaration: (source) => {
       const path = getPathAsString(source.container, source.index)
@@ -118,7 +102,7 @@ export class ZenScriptScopeProvider extends DefaultScopeProvider {
           case TypeParameter:
             return
           case ImportDeclaration: {
-            return this.importAlias(desc)
+            return this.descriptionIndex.createImportedDescription(desc.node as ImportDeclaration)
           }
           default:
             return desc
@@ -142,7 +126,7 @@ export class ZenScriptScopeProvider extends DefaultScopeProvider {
             case ClassDeclaration:
               return desc
             case ImportDeclaration: {
-              return this.importAlias(desc)
+              return this.descriptionIndex.createImportedDescription(desc.node as ImportDeclaration)
             }
           }
         }

--- a/packages/zenscript/src/workspace/description-index.ts
+++ b/packages/zenscript/src/workspace/description-index.ts
@@ -1,0 +1,55 @@
+import type { HierarchyNode } from '@intellizen/shared'
+import type { AstNode, AstNodeDescription, AstNodeDescriptionProvider } from 'langium'
+import type { ClassDeclaration } from '../generated/ast'
+import type { ZenScriptServices } from '../module'
+import { createSyntheticAstNodeDescription } from '../reference/synthetic'
+
+export interface DescriptionIndex {
+  getDescription: (astNode: AstNode) => AstNodeDescription
+  getPackageDescription: (pkgNode: HierarchyNode<AstNode>) => AstNodeDescription
+  getThisDescription: (classDecl: ClassDeclaration) => AstNodeDescription
+  createDynamicDescription: (astNode: AstNode, name: string) => AstNodeDescription
+}
+
+export class ZenScriptDescriptionIndex implements DescriptionIndex {
+  private readonly descriptions: AstNodeDescriptionProvider
+
+  private readonly astDescriptions: WeakMap<AstNode, AstNodeDescription>
+  private readonly pkgDescriptions: WeakMap<HierarchyNode<AstNode>, AstNodeDescription>
+  private readonly thisDescriptions: WeakMap<ClassDeclaration, AstNodeDescription>
+
+  constructor(services: ZenScriptServices) {
+    this.descriptions = services.workspace.AstNodeDescriptionProvider
+    this.astDescriptions = new WeakMap()
+    this.pkgDescriptions = new WeakMap()
+    this.thisDescriptions = new WeakMap()
+  }
+
+  getDescription(astNode: AstNode): AstNodeDescription {
+    if (!this.astDescriptions.has(astNode)) {
+      this.astDescriptions.set(astNode, this.descriptions.createDescription(astNode, undefined))
+    }
+    return this.astDescriptions.get(astNode)!
+  }
+
+  getPackageDescription(pkgNode: HierarchyNode<AstNode>): AstNodeDescription {
+    if (pkgNode.isDataNode()) {
+      throw new Error(`Expected a package node, but received a data node: ${pkgNode}`)
+    }
+    if (!this.pkgDescriptions.has(pkgNode)) {
+      this.pkgDescriptions.set(pkgNode, createSyntheticAstNodeDescription('SyntheticHierarchyNode', pkgNode.name, pkgNode))
+    }
+    return this.pkgDescriptions.get(pkgNode)!
+  }
+
+  getThisDescription(classDecl: ClassDeclaration): AstNodeDescription {
+    if (!this.thisDescriptions.has(classDecl)) {
+      this.thisDescriptions.set(classDecl, this.descriptions.createDescription(classDecl, 'this'))
+    }
+    return this.thisDescriptions.get(classDecl)!
+  }
+
+  createDynamicDescription(astNode: AstNode, name: string): AstNodeDescription {
+    return this.descriptions.createDescription(astNode, name)
+  }
+}

--- a/packages/zenscript/src/workspace/description-index.ts
+++ b/packages/zenscript/src/workspace/description-index.ts
@@ -9,6 +9,8 @@ export interface DescriptionIndex {
   getPackageDescription: (pkgNode: HierarchyNode<AstNode>) => AstNodeDescription
   getThisDescription: (classDecl: ClassDeclaration) => AstNodeDescription
   createDynamicDescription: (astNode: AstNode, name: string) => AstNodeDescription
+  // create ast node description with alias name, reusing some info, for better performance
+  createAliasDescription: (origin: AstNodeDescription, newName: string) => AstNodeDescription
 }
 
 export class ZenScriptDescriptionIndex implements DescriptionIndex {
@@ -51,5 +53,23 @@ export class ZenScriptDescriptionIndex implements DescriptionIndex {
 
   createDynamicDescription(astNode: AstNode, name: string): AstNodeDescription {
     return this.descriptions.createDescription(astNode, name)
+  }
+
+  createAliasDescription(origin: AstNodeDescription, newName: string): AstNodeDescription {
+    if (newName === origin.name) {
+      return origin
+    }
+    const { node, selectionSegment, type, documentUri, path } = origin
+    return {
+      node,
+      name: newName,
+      get nameSegment() {
+        return origin.nameSegment
+      },
+      selectionSegment,
+      type,
+      documentUri,
+      path,
+    }
   }
 }

--- a/packages/zenscript/src/workspace/description-index.ts
+++ b/packages/zenscript/src/workspace/description-index.ts
@@ -1,6 +1,6 @@
 import type { HierarchyNode } from '@intellizen/shared'
 import type { AstNode, AstNodeDescription, AstNodeDescriptionProvider } from 'langium'
-import type { ClassDeclaration } from '../generated/ast'
+import type { ClassDeclaration, ImportDeclaration } from '../generated/ast'
 import type { ZenScriptServices } from '../module'
 import { createSyntheticAstNodeDescription } from '../reference/synthetic'
 
@@ -9,7 +9,7 @@ export interface DescriptionIndex {
   getPackageDescription: (pkgNode: HierarchyNode<AstNode>) => AstNodeDescription
   getThisDescription: (classDecl: ClassDeclaration) => AstNodeDescription
   createDynamicDescription: (astNode: AstNode, name: string) => AstNodeDescription
-  createAliasDescription: (origin: AstNodeDescription, alias: string) => AstNodeDescription
+  createImportedDescription: (importDecl: ImportDeclaration) => AstNodeDescription
 }
 
 export class ZenScriptDescriptionIndex implements DescriptionIndex {
@@ -54,7 +54,8 @@ export class ZenScriptDescriptionIndex implements DescriptionIndex {
     return this.descriptions.createDescription(astNode, name)
   }
 
-  createAliasDescription(origin: AstNodeDescription, alias: string): AstNodeDescription {
-    return Object.assign({ name: alias }, origin)
+  createImportedDescription(importDecl: ImportDeclaration): AstNodeDescription {
+    const ref = importDecl.path.at(-1)?.ref ?? importDecl
+    return this.descriptions.createDescription(ref, undefined)
   }
 }

--- a/packages/zenscript/src/workspace/description-index.ts
+++ b/packages/zenscript/src/workspace/description-index.ts
@@ -9,8 +9,7 @@ export interface DescriptionIndex {
   getPackageDescription: (pkgNode: HierarchyNode<AstNode>) => AstNodeDescription
   getThisDescription: (classDecl: ClassDeclaration) => AstNodeDescription
   createDynamicDescription: (astNode: AstNode, name: string) => AstNodeDescription
-  // create ast node description with alias name, reusing some info, for better performance
-  createAliasDescription: (origin: AstNodeDescription, newName: string) => AstNodeDescription
+  createAliasDescription: (origin: AstNodeDescription, alias: string) => AstNodeDescription
 }
 
 export class ZenScriptDescriptionIndex implements DescriptionIndex {
@@ -55,21 +54,7 @@ export class ZenScriptDescriptionIndex implements DescriptionIndex {
     return this.descriptions.createDescription(astNode, name)
   }
 
-  createAliasDescription(origin: AstNodeDescription, newName: string): AstNodeDescription {
-    if (newName === origin.name) {
-      return origin
-    }
-    const { node, selectionSegment, type, documentUri, path } = origin
-    return {
-      node,
-      name: newName,
-      get nameSegment() {
-        return origin.nameSegment
-      },
-      selectionSegment,
-      type,
-      documentUri,
-      path,
-    }
+  createAliasDescription(origin: AstNodeDescription, alias: string): AstNodeDescription {
+    return Object.assign({ name: alias }, origin)
   }
 }

--- a/packages/zenscript/src/workspace/description-index.ts
+++ b/packages/zenscript/src/workspace/description-index.ts
@@ -1,5 +1,5 @@
 import type { HierarchyNode } from '@intellizen/shared'
-import type { AstNode, AstNodeDescription, AstNodeDescriptionProvider } from 'langium'
+import type { AstNode, AstNodeDescription, AstNodeDescriptionProvider, NameProvider } from 'langium'
 import type { ClassDeclaration, ImportDeclaration } from '../generated/ast'
 import type { ZenScriptServices } from '../module'
 import { createSyntheticAstNodeDescription } from '../reference/synthetic'
@@ -14,6 +14,7 @@ export interface DescriptionIndex {
 
 export class ZenScriptDescriptionIndex implements DescriptionIndex {
   private readonly descriptions: AstNodeDescriptionProvider
+  private readonly nameProvider: NameProvider
 
   readonly astDescriptions: WeakMap<AstNode, AstNodeDescription>
   readonly pkgDescriptions: WeakMap<HierarchyNode<AstNode>, AstNodeDescription>
@@ -21,6 +22,7 @@ export class ZenScriptDescriptionIndex implements DescriptionIndex {
 
   constructor(services: ZenScriptServices) {
     this.descriptions = services.workspace.AstNodeDescriptionProvider
+    this.nameProvider = services.references.NameProvider
     this.astDescriptions = new WeakMap()
     this.pkgDescriptions = new WeakMap()
     this.thisDescriptions = new WeakMap()
@@ -56,6 +58,6 @@ export class ZenScriptDescriptionIndex implements DescriptionIndex {
 
   createImportedDescription(importDecl: ImportDeclaration): AstNodeDescription {
     const ref = importDecl.path.at(-1)?.ref ?? importDecl
-    return this.descriptions.createDescription(ref, undefined)
+    return this.descriptions.createDescription(ref, this.nameProvider.getName(importDecl))
   }
 }

--- a/packages/zenscript/src/workspace/description-index.ts
+++ b/packages/zenscript/src/workspace/description-index.ts
@@ -14,9 +14,9 @@ export interface DescriptionIndex {
 export class ZenScriptDescriptionIndex implements DescriptionIndex {
   private readonly descriptions: AstNodeDescriptionProvider
 
-  private readonly astDescriptions: WeakMap<AstNode, AstNodeDescription>
-  private readonly pkgDescriptions: WeakMap<HierarchyNode<AstNode>, AstNodeDescription>
-  private readonly thisDescriptions: WeakMap<ClassDeclaration, AstNodeDescription>
+  readonly astDescriptions: WeakMap<AstNode, AstNodeDescription>
+  readonly pkgDescriptions: WeakMap<HierarchyNode<AstNode>, AstNodeDescription>
+  readonly thisDescriptions: WeakMap<ClassDeclaration, AstNodeDescription>
 
   constructor(services: ZenScriptServices) {
     this.descriptions = services.workspace.AstNodeDescriptionProvider


### PR DESCRIPTION
Based on the findings from #59, directly depending on `AstNodeDescriptionProvider` and invoking `createDescription` each time may lead to performance issues. The retrieval and creation of descriptions should be handled by the `DescriptionIndex` service.
