### PR TITLE
refactor: put the files required for the extensions into `vscode-extension`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       ],
       "sourceMaps": true,
       "outFiles": [
-        "${workspaceRoot}/out/**/*.cjs"
+        "${workspaceRoot}/packages/vscode-extension/out/**/*.cjs"
       ],
       "trace": true,
       "autoAttachChildProcesses": true
@@ -25,7 +25,7 @@
       ],
       "sourceMaps": true,
       "outFiles": [
-        "${workspaceRoot}/out/**/*.cjs",
+        "${workspaceRoot}/packages/vscode-extension/out/**/*.cjs",
         "${workspaceRoot}/node_modules/langium"
       ]
     }

--- a/packages/vscode-extension/LICENSE
+++ b/packages/vscode-extension/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 intellizen-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -15,14 +15,15 @@
   "bugs": {
     "url": "https://github.com/intellizen-dev/intellizen/issues"
   },
-  "main": "../../out/extension/main.cjs",
+  "main": "out/extension/main.cjs",
   "files": [
     "LICENSE",
+    "language-configuration.json",
     "out/**/*",
     "syntaxes"
   ],
   "engines": {
-    "vscode": "^1.92.0"
+    "vscode": "^1.95.0"
   },
   "contributes": {
     "languages": [
@@ -46,6 +47,9 @@
         "path": "syntaxes/zenscript.tmLanguage.json"
       }
     ]
+  },
+  "vsce": {
+    "dependencies": false
   },
   "scripts": {
     "dev": "pnpm build --watch",

--- a/packages/vscode-extension/src/main.ts
+++ b/packages/vscode-extension/src/main.ts
@@ -20,7 +20,7 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 function startLanguageClient(context: ExtensionContext): LanguageClient {
-  const serverModule = context.asAbsolutePath(join('..', '..', 'out', 'intellizen-zenscript', 'main.cjs'))
+  const serverModule = context.asAbsolutePath(join('out', 'intellizen-zenscript', 'main.cjs'))
   // The debug options for the server
   // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging.
   // By setting `process.env.DEBUG_BREAK` to a truthy value, the language server will wait until a debugger is attached.

--- a/packages/vscode-extension/tsup.config.ts
+++ b/packages/vscode-extension/tsup.config.ts
@@ -3,6 +3,6 @@ import DefaultConfig from '../../tsup-default.config'
 
 export default defineConfig({
   ...DefaultConfig,
-  outDir: '../../out/extension',
+  outDir: 'out/extension',
   noExternal: ['vscode-languageclient', '@intellizen/shared'],
 })

--- a/packages/zenscript/tsup.config.ts
+++ b/packages/zenscript/tsup.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { defineConfig } from 'tsup'
 import DefaultConfig from '../../tsup-default.config'
 
-const outDir = '../../out/intellizen-zenscript'
+const outDir = '../vscode-extension/out/intellizen-zenscript'
 const builtinsSrc = resolve(__dirname, 'src', 'builtins')
 const builtinsDest = resolve(__dirname, outDir, 'builtins')
 


### PR DESCRIPTION
No merge for now, waiting for the github action to be written.

To temporarily package vsce, execute the following commands in sequence:
```shell
npm install -g @vscode/vsce ovsx
cd packages/vscode-extensions
vsce package
```