### PR TITLE
feat: improve error reporting experience

### DIFF
--- a/packages/zenscript/src/module.ts
+++ b/packages/zenscript/src/module.ts
@@ -10,6 +10,7 @@ import { ZenScriptInlayHintProvider } from './lsp/inlay-hint-provider'
 import { ZenScriptNodeKindProvider } from './lsp/node-kind-provider'
 import { ZenScriptSemanticTokenProvider } from './lsp/semantic-token-provider'
 import { ZenScriptDynamicProvider } from './reference/dynamic-provider'
+import { ZenScriptLinker } from './reference/linker'
 import { ZenScriptMemberProvider } from './reference/member-provider'
 import { ZenScriptNameProvider } from './reference/name-provider'
 import { ZenScriptScopeComputation } from './reference/scope-computation'
@@ -76,6 +77,7 @@ export const ZenScriptModule: Module<ZenScriptServices, PartialLangiumServices &
     ScopeProvider: services => new ZenScriptScopeProvider(services),
     MemberProvider: services => new ZenScriptMemberProvider(services),
     DynamicProvider: services => new ZenScriptDynamicProvider(services),
+    Linker: services => new ZenScriptLinker(services),
   },
   workspace: {
     AstNodeDescriptionProvider: services => new ZenScriptDescriptionCreator(services),

--- a/packages/zenscript/src/reference/linker.ts
+++ b/packages/zenscript/src/reference/linker.ts
@@ -1,0 +1,29 @@
+import type { AstNodeDescription, LinkingError, ReferenceInfo } from 'langium'
+import type { ZenScriptServices } from '../module'
+import { DefaultLinker } from 'langium'
+import { isImportDeclaration, isNamedTypeReference } from '../generated/ast'
+import { createUnknownAstDescription } from './synthetic'
+
+export class ZenScriptLinker extends DefaultLinker {
+  constructor(services: ZenScriptServices) {
+    super(services)
+  }
+
+  override getCandidate(refInfo: ReferenceInfo): AstNodeDescription | LinkingError {
+    const scope = this.scopeProvider.getScope(refInfo)
+    const description = scope.getElement(refInfo.reference.$refText)
+    if (description) {
+      return description
+    }
+
+    if (isImportDeclaration(refInfo.container) && refInfo.container.path.some(it => it.error)) {
+      return createUnknownAstDescription(refInfo.reference.$refText)
+    }
+
+    if (isNamedTypeReference(refInfo.container) && refInfo.container.path.some(it => it.error)) {
+      return createUnknownAstDescription(refInfo.reference.$refText)
+    }
+
+    return this.createLinkingError(refInfo)
+  }
+}

--- a/packages/zenscript/src/reference/synthetic.ts
+++ b/packages/zenscript/src/reference/synthetic.ts
@@ -1,8 +1,26 @@
-import type { AstNode } from 'langium'
+import type { AstNode, AstNodeDescription } from 'langium'
 import type { HierarchyNode } from '../utils/hierarchy-tree'
+import { URI } from 'langium'
 
 export interface ZenScriptSyntheticAstType {
   SyntheticHierarchyNode: HierarchyNode<AstNode>
+  SyntheticUnknown: AstNode
+}
+
+export function createUnknownAstDescription(name: string): AstNodeDescription {
+  return {
+    name,
+    node: createUnknownAst(),
+    type: 'SyntheticUnknown',
+    documentUri: URI.from({ scheme: 'unknown' }),
+    path: '',
+  }
+}
+
+export function createUnknownAst(): AstNode {
+  return {
+    $type: 'SyntheticUnknown',
+  }
 }
 
 export function isSyntheticAstNode(node: AstNode): boolean {


### PR DESCRIPTION
This PR improves error reporting for qualified names by showing only one error.

For example:
```zenscript
import unknown.unknown.unknown;
```
Instead of listing all errors (which can be annoying), we only report the first `unknown`.